### PR TITLE
Make this add-on work in Plone 4.3

### DIFF
--- a/collective/tinymcetemplates/browser.py
+++ b/collective/tinymcetemplates/browser.py
@@ -1,17 +1,14 @@
 try:
     import json
 except ImportError:
-    import simplejson as json
+    from simplejson import json
 
 from zope.component import queryUtility
 from zope.publisher.browser import BrowserView
 
 from plone.registry.interfaces import IRegistry
 
-try:
-    from Products.ATContentTypes.interfaces.document import IATDocument
-except:
-    from Products.ATContentTypes.interface import IATDocument
+from Products.ATContentTypes.interfaces.document import IATDocument
 from Products.CMFCore.utils import getToolByName
 
 class TemplateList(BrowserView):
@@ -38,6 +35,6 @@ class TemplateList(BrowserView):
                     paths.append("%s/%s" % (portal_path, p,))
                 
                 for r in portal_catalog(path=paths, object_provides=IATDocument.__identifier__):
-                    templates.append([r.Title, "%s/getText" % r.getURL(), r.Description])
+                    templates.append([r.Title,  r.getURL(), r.Description])
         
         return u"var tinyMCETemplateList = %s;" % json.dumps(templates)

--- a/collective/tinymcetemplates/plugin/js/template.js
+++ b/collective/tinymcetemplates/plugin/js/template.js
@@ -105,7 +105,13 @@ var TemplateDialog = {
         x.open("GET", u, false);
         x.send(null);
 
-        return x.responseText;
+        var html_doc = x.response;
+        var parser = new DOMParser();
+        var doc = parser.parseFromString(html_doc, "text/html");
+          
+        result =  doc.querySelectorAll("[id^=parent-fieldname-text]")[0].innerHTML;
+
+        return result;
     }
 };
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '1.0b4htug1'
+version = '1.0b4magenta'
 shortdesc = "TinyMCE Plugin for templates and snippets"
 longdesc = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
 longdesc += open(os.path.join(os.path.dirname(__file__), 'HISTORY.rst')).read()


### PR DESCRIPTION
The add-on does not work for my client's web site in Plone ¤.3, since the "/getText" URL no longer(?) returns the contents of the text field.

Instead, I search for the text field in the HTML for the whole page and return its innerHTML. The payload of these changes is thus in the template.hs file.